### PR TITLE
updates emit to work with scoped vars

### DIFF
--- a/selbench-fx-xpi/chrome/content/extensions/selbench.js
+++ b/selbench-fx-xpi/chrome/content/extensions/selbench.js
@@ -46,7 +46,7 @@ function $d() { return selenium.browserbot.getDocument(); }
       catch (err) {
         throw new Error("In " + err.fileName + " @" + err.lineNumber + ": " + err);
       }
-      storedVars.emitted = "";
+      storedVarsGlobal.emitted = "";
     };
   })();
 
@@ -76,11 +76,6 @@ function $d() { return selenium.browserbot.getDocument(); }
   // ================================================================================
   // emit execution tracing
 
-  function evalWithVars(expr) {
-    return eval("with (storedVars) {" + expr + "}");
-  }
-
-
   // ================================================================================
   Selenium.prototype.doExpectError = function(target) {
     $$.expectedError = eval(target);
@@ -92,9 +87,9 @@ function $d() { return selenium.browserbot.getDocument(); }
   // appends the given string to current emitted state, (a ~ is inserted between each append)
   Selenium.prototype.doEmit = function(target)
   {
-    if (storedVars.emitted)
-      storedVars.emitted += "~";
-    storedVars.emitted += evalWithVars(target);
+    if (storedVarsGlobal.emitted)
+      storedVarsGlobal.emitted += "~";
+    storedVarsGlobal.emitted += evalWithVars(target);
   };
   // verifies that the accumulated emit state matches the given string
   // if an array is specified, then matches for a ~ between each element
@@ -104,8 +99,8 @@ function $d() { return selenium.browserbot.getDocument(); }
     if (expectedValue instanceof Array) {
       expectedValue = expectedValue.join("~");
     }
-    if (expectedValue != storedVars.emitted) {
-      var errmsg = " expected: " + expectedValue + "\nbut found: " + storedVars.emitted;
+    if (expectedValue != storedVarsGlobal.emitted) {
+      var errmsg = " expected: " + expectedValue + "\nbut found: " + storedVarsGlobal.emitted;
       alert(errmsg);
       throw new Error(errmsg);
     }
@@ -113,7 +108,7 @@ function $d() { return selenium.browserbot.getDocument(); }
   // clears the accumulated emitted state
   Selenium.prototype.doResetEmitted = function()
   {
-    storedVars.emitted = "";
+    storedVarsGlobal.emitted = "";
   };
 
   // ================================================================================
@@ -132,17 +127,19 @@ function $d() { return selenium.browserbot.getDocument(); }
   Selenium.prototype.doAlert = function(expr) {
     alert(evalWithVars(expr));
   };
-
+  
   // remove selenium variable
-  Selenium.prototype.doDeleteVar = function(name) {
-    delete storedVars[name];
+  function deleteVar(name) {
+    delete storedVarsLocal[name];
+    delete storedVarsGlobal[name]
   };
+  Selenium.prototype.doDeleteVar = deleteVar;
 
   // remove selenium variable
   Selenium.prototype.doDeleteVars = function(namesSpec) {
     var names = namesSpec.split(",");
     for (var i = 0; i < names.length; i++) {
-      delete storedVars[names[i].trim()];
+      deleteVar(names[i].trim());
     }
   };
 
@@ -174,7 +171,7 @@ function $d() { return selenium.browserbot.getDocument(); }
   Selenium.prototype.doTimerElapsed = function(name, script)
   {
     if (script) {
-      storedVars._elapsed = timers[name].elapsed();
+      storedVarsGlobal._elapsed = timers[name].elapsed();
       eval(script);
     }
     else


### PR DESCRIPTION
These updates are related to https://github.com/refactoror/SelBlocks/pull/19 You'll need them in order to run all the preexisting and new tests for SelBlocks that are in that branch.

Since storedVars has to be block scoped now, emit and others access
storedVarsGlobal to do the same thing they used to.

Also, evalWithVars was defined twice in here, in exactly the same way,
so I removed one of them.